### PR TITLE
Use correct godog import path

### DIFF
--- a/assert_godog_test.go
+++ b/assert_godog_test.go
@@ -2,8 +2,8 @@ package assert
 
 import (
 	"flag"
-	"github.com/DATA-DOG/godog"
-	"github.com/DATA-DOG/godog/colors"
+	"github.com/cucumber/godog"
+	"github.com/cucumber/godog/colors"
 	"os"
 	"testing"
 )


### PR DESCRIPTION
Currently `go mod tidy` fails for any modules-enabled project depending from "github.com/christianhujer/assert", even indirectly :(